### PR TITLE
Add simple Tkinter desktop Todo app with JSON persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # YBKC DeepLearning Test Repository 
 
 Study Url : https://ykcb.gitbook.io/-1/
+
+## Desktop Todo App
+
+간단한 데스크탑 할 일 앱(`todo_desktop_app.py`)을 추가했습니다.
+
+### 실행 방법
+
+```bash
+python3 todo_desktop_app.py
+```
+
+### 주요 기능
+
+- 할 일 추가
+- 더블 클릭 또는 버튼으로 완료 상태 토글
+- 선택 항목 삭제
+- 완료 항목 일괄 정리
+- 전체/진행중/완료 필터
+- JSON 파일(`todo_data.json`)로 자동 저장

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Study Url : https://ykcb.gitbook.io/-1/
 
 ## Desktop Todo App
 
-간단한 데스크탑 할 일 앱(`todo_desktop_app.py`)을 추가했습니다.
+간단한 데스크탑 할 일 앱(`todo_desktop_app.py`)입니다.
 
 ### 실행 방법
 
@@ -12,11 +12,22 @@ Study Url : https://ykcb.gitbook.io/-1/
 python3 todo_desktop_app.py
 ```
 
+또는 실행 스크립트:
+
+```bash
+./run_todo_app.sh
+```
+
 ### 주요 기능
 
-- 할 일 추가
+- 할 일 추가 / 수정 / 삭제
 - 더블 클릭 또는 버튼으로 완료 상태 토글
-- 선택 항목 삭제
 - 완료 항목 일괄 정리
 - 전체/진행중/완료 필터
+- 단축키 지원 (Ctrl+D, Ctrl+E, Delete, Ctrl+N)
 - JSON 파일(`todo_data.json`)로 자동 저장
+
+### 참고
+
+- 리눅스 서버처럼 GUI가 없는 환경에서는 창이 뜨지 않습니다.
+- 데스크탑 환경(Windows/macOS/Linux GUI)에서 실행해 주세요.

--- a/run_todo_app.sh
+++ b/run_todo_app.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+python3 todo_desktop_app.py

--- a/todo_desktop_app.py
+++ b/todo_desktop_app.py
@@ -1,9 +1,8 @@
 """Simple desktop To-Do application using Tkinter.
 
 Features:
-- Add tasks
+- Add, edit, delete tasks
 - Mark task as done / not done
-- Delete selected task
 - Filter all/active/completed tasks
 - Persist tasks to a local JSON file
 """
@@ -11,10 +10,10 @@ Features:
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import messagebox, simpledialog, ttk
 
 
 DATA_FILE = Path(__file__).with_name("todo_data.json")
@@ -30,13 +29,14 @@ class TodoApp(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title("Todo App")
-        self.geometry("520x500")
-        self.minsize(460, 420)
+        self.geometry("560x540")
+        self.minsize(500, 440)
 
         self.todos: list[TodoItem] = self._load_todos()
         self.filter_mode = tk.StringVar(value="all")
 
         self._create_widgets()
+        self._bind_shortcuts()
         self._refresh_list()
 
     def _create_widgets(self) -> None:
@@ -53,14 +53,13 @@ class TodoApp(tk.Tk):
         self.task_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
         self.task_entry.bind("<Return>", lambda _event: self.add_task())
 
-        add_btn = ttk.Button(input_row, text="추가", command=self.add_task)
-        add_btn.pack(side=tk.LEFT, padx=(8, 0))
+        ttk.Button(input_row, text="추가", command=self.add_task).pack(side=tk.LEFT, padx=(8, 0))
 
         filter_row = ttk.Frame(container)
         filter_row.pack(fill=tk.X, pady=(0, 8))
 
         ttk.Label(filter_row, text="보기:").pack(side=tk.LEFT)
-        for key, label in [("all", "전체"), ("active", "진행중"), ("done", "완료")]:
+        for key, label in (("all", "전체"), ("active", "진행중"), ("done", "완료")):
             ttk.Radiobutton(
                 filter_row,
                 text=label,
@@ -69,25 +68,41 @@ class TodoApp(tk.Tk):
                 command=self._refresh_list,
             ).pack(side=tk.LEFT, padx=4)
 
+        list_frame = ttk.Frame(container)
+        list_frame.pack(fill=tk.BOTH, expand=True)
+
         self.todo_listbox = tk.Listbox(
-            container,
+            list_frame,
             selectmode=tk.SINGLE,
             activestyle="none",
             font=("Arial", 12),
         )
-        self.todo_listbox.pack(fill=tk.BOTH, expand=True)
+        self.todo_listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.todo_listbox.bind("<Double-Button-1>", lambda _event: self.toggle_task())
+
+        scrollbar = ttk.Scrollbar(list_frame, orient=tk.VERTICAL, command=self.todo_listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.todo_listbox.config(yscrollcommand=scrollbar.set)
 
         action_row = ttk.Frame(container)
         action_row.pack(fill=tk.X, pady=(10, 0))
 
         ttk.Button(action_row, text="완료 토글", command=self.toggle_task).pack(side=tk.LEFT)
-        ttk.Button(action_row, text="삭제", command=self.delete_task).pack(side=tk.LEFT, padx=8)
+        ttk.Button(action_row, text="수정", command=self.edit_task).pack(side=tk.LEFT, padx=8)
+        ttk.Button(action_row, text="삭제", command=self.delete_task).pack(side=tk.LEFT)
         ttk.Button(action_row, text="완료 항목 정리", command=self.clear_done).pack(side=tk.RIGHT)
 
         self.status_var = tk.StringVar(value="할 일을 입력해 주세요.")
-        status = ttk.Label(container, textvariable=self.status_var)
-        status.pack(anchor="w", pady=(8, 0))
+        ttk.Label(container, textvariable=self.status_var).pack(anchor="w", pady=(8, 0))
+
+        guide_text = "단축키: Enter(추가), Ctrl+D(완료 토글), Ctrl+E(수정), Delete(삭제), Ctrl+N(입력창 이동)"
+        ttk.Label(container, text=guide_text, foreground="#666").pack(anchor="w", pady=(6, 0))
+
+    def _bind_shortcuts(self) -> None:
+        self.bind("<Delete>", lambda _event: self.delete_task())
+        self.bind("<Control-d>", lambda _event: self.toggle_task())
+        self.bind("<Control-e>", lambda _event: self.edit_task())
+        self.bind("<Control-n>", lambda _event: self.task_entry.focus_set())
 
     def _filtered_indices(self) -> list[int]:
         mode = self.filter_mode.get()
@@ -104,15 +119,15 @@ class TodoApp(tk.Tk):
 
     def _refresh_list(self) -> None:
         self.todo_listbox.delete(0, tk.END)
-        indices = self._filtered_indices()
-        for idx in indices:
+        for idx in self._filtered_indices():
             item = self.todos[idx]
             prefix = "✅" if item.done else "⬜"
             self.todo_listbox.insert(tk.END, f"{prefix} {item.text}")
 
         total = len(self.todos)
         done = sum(item.done for item in self.todos)
-        self.status_var.set(f"전체 {total}개 / 완료 {done}개")
+        active = total - done
+        self.status_var.set(f"전체 {total}개 / 진행중 {active}개 / 완료 {done}개")
 
     def add_task(self) -> None:
         text = self.task_entry.get().strip()
@@ -131,7 +146,9 @@ class TodoApp(tk.Tk):
             return None
 
         filtered_indices = self._filtered_indices()
-        return filtered_indices[selection[0]] if filtered_indices else None
+        if not filtered_indices:
+            return None
+        return filtered_indices[selection[0]]
 
     def toggle_task(self) -> None:
         idx = self._selected_actual_index()
@@ -143,10 +160,32 @@ class TodoApp(tk.Tk):
         self._save_todos()
         self._refresh_list()
 
+    def edit_task(self) -> None:
+        idx = self._selected_actual_index()
+        if idx is None:
+            messagebox.showinfo("안내", "먼저 항목을 선택해 주세요.")
+            return
+
+        new_text = simpledialog.askstring("할 일 수정", "수정할 내용을 입력해 주세요.", initialvalue=self.todos[idx].text)
+        if new_text is None:
+            return
+
+        text = new_text.strip()
+        if not text:
+            messagebox.showinfo("안내", "빈 내용으로 수정할 수 없습니다.")
+            return
+
+        self.todos[idx].text = text
+        self._save_todos()
+        self._refresh_list()
+
     def delete_task(self) -> None:
         idx = self._selected_actual_index()
         if idx is None:
             messagebox.showinfo("안내", "먼저 항목을 선택해 주세요.")
+            return
+
+        if not messagebox.askyesno("삭제 확인", "선택한 항목을 삭제할까요?"):
             return
 
         del self.todos[idx]
@@ -171,7 +210,7 @@ class TodoApp(tk.Tk):
 
         try:
             data = json.loads(DATA_FILE.read_text(encoding="utf-8"))
-            return [TodoItem(**item) for item in data if "text" in item]
+            return [TodoItem(**item) for item in data if isinstance(item, dict) and "text" in item]
         except (OSError, json.JSONDecodeError, TypeError):
             return []
 
@@ -179,12 +218,21 @@ class TodoApp(tk.Tk):
         try:
             payload = [asdict(item) for item in self.todos]
             DATA_FILE.write_text(
-                json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
             )
         except OSError:
             messagebox.showerror("저장 오류", "할 일 목록을 저장하지 못했습니다.")
 
 
+def main() -> None:
+    try:
+        app = TodoApp()
+        app.mainloop()
+    except tk.TclError as error:
+        print("GUI 실행에 필요한 디스플레이 환경을 찾지 못했습니다.")
+        print(f"상세 오류: {error}")
+
+
 if __name__ == "__main__":
-    app = TodoApp()
-    app.mainloop()
+    main()

--- a/todo_desktop_app.py
+++ b/todo_desktop_app.py
@@ -1,0 +1,190 @@
+"""Simple desktop To-Do application using Tkinter.
+
+Features:
+- Add tasks
+- Mark task as done / not done
+- Delete selected task
+- Filter all/active/completed tasks
+- Persist tasks to a local JSON file
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+
+DATA_FILE = Path(__file__).with_name("todo_data.json")
+
+
+@dataclass
+class TodoItem:
+    text: str
+    done: bool = False
+
+
+class TodoApp(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Todo App")
+        self.geometry("520x500")
+        self.minsize(460, 420)
+
+        self.todos: list[TodoItem] = self._load_todos()
+        self.filter_mode = tk.StringVar(value="all")
+
+        self._create_widgets()
+        self._refresh_list()
+
+    def _create_widgets(self) -> None:
+        container = ttk.Frame(self, padding=12)
+        container.pack(fill=tk.BOTH, expand=True)
+
+        title = ttk.Label(container, text="오늘 할 일", font=("Arial", 16, "bold"))
+        title.pack(anchor="w", pady=(0, 10))
+
+        input_row = ttk.Frame(container)
+        input_row.pack(fill=tk.X, pady=(0, 8))
+
+        self.task_entry = ttk.Entry(input_row)
+        self.task_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        self.task_entry.bind("<Return>", lambda _event: self.add_task())
+
+        add_btn = ttk.Button(input_row, text="추가", command=self.add_task)
+        add_btn.pack(side=tk.LEFT, padx=(8, 0))
+
+        filter_row = ttk.Frame(container)
+        filter_row.pack(fill=tk.X, pady=(0, 8))
+
+        ttk.Label(filter_row, text="보기:").pack(side=tk.LEFT)
+        for key, label in [("all", "전체"), ("active", "진행중"), ("done", "완료")]:
+            ttk.Radiobutton(
+                filter_row,
+                text=label,
+                value=key,
+                variable=self.filter_mode,
+                command=self._refresh_list,
+            ).pack(side=tk.LEFT, padx=4)
+
+        self.todo_listbox = tk.Listbox(
+            container,
+            selectmode=tk.SINGLE,
+            activestyle="none",
+            font=("Arial", 12),
+        )
+        self.todo_listbox.pack(fill=tk.BOTH, expand=True)
+        self.todo_listbox.bind("<Double-Button-1>", lambda _event: self.toggle_task())
+
+        action_row = ttk.Frame(container)
+        action_row.pack(fill=tk.X, pady=(10, 0))
+
+        ttk.Button(action_row, text="완료 토글", command=self.toggle_task).pack(side=tk.LEFT)
+        ttk.Button(action_row, text="삭제", command=self.delete_task).pack(side=tk.LEFT, padx=8)
+        ttk.Button(action_row, text="완료 항목 정리", command=self.clear_done).pack(side=tk.RIGHT)
+
+        self.status_var = tk.StringVar(value="할 일을 입력해 주세요.")
+        status = ttk.Label(container, textvariable=self.status_var)
+        status.pack(anchor="w", pady=(8, 0))
+
+    def _filtered_indices(self) -> list[int]:
+        mode = self.filter_mode.get()
+        indices: list[int] = []
+
+        for i, item in enumerate(self.todos):
+            if mode == "all":
+                indices.append(i)
+            elif mode == "active" and not item.done:
+                indices.append(i)
+            elif mode == "done" and item.done:
+                indices.append(i)
+        return indices
+
+    def _refresh_list(self) -> None:
+        self.todo_listbox.delete(0, tk.END)
+        indices = self._filtered_indices()
+        for idx in indices:
+            item = self.todos[idx]
+            prefix = "✅" if item.done else "⬜"
+            self.todo_listbox.insert(tk.END, f"{prefix} {item.text}")
+
+        total = len(self.todos)
+        done = sum(item.done for item in self.todos)
+        self.status_var.set(f"전체 {total}개 / 완료 {done}개")
+
+    def add_task(self) -> None:
+        text = self.task_entry.get().strip()
+        if not text:
+            messagebox.showinfo("안내", "할 일을 입력해 주세요.")
+            return
+
+        self.todos.append(TodoItem(text=text))
+        self.task_entry.delete(0, tk.END)
+        self._save_todos()
+        self._refresh_list()
+
+    def _selected_actual_index(self) -> int | None:
+        selection = self.todo_listbox.curselection()
+        if not selection:
+            return None
+
+        filtered_indices = self._filtered_indices()
+        return filtered_indices[selection[0]] if filtered_indices else None
+
+    def toggle_task(self) -> None:
+        idx = self._selected_actual_index()
+        if idx is None:
+            messagebox.showinfo("안내", "먼저 항목을 선택해 주세요.")
+            return
+
+        self.todos[idx].done = not self.todos[idx].done
+        self._save_todos()
+        self._refresh_list()
+
+    def delete_task(self) -> None:
+        idx = self._selected_actual_index()
+        if idx is None:
+            messagebox.showinfo("안내", "먼저 항목을 선택해 주세요.")
+            return
+
+        del self.todos[idx]
+        self._save_todos()
+        self._refresh_list()
+
+    def clear_done(self) -> None:
+        before = len(self.todos)
+        self.todos = [item for item in self.todos if not item.done]
+        removed = before - len(self.todos)
+
+        if removed == 0:
+            messagebox.showinfo("안내", "완료된 항목이 없습니다.")
+            return
+
+        self._save_todos()
+        self._refresh_list()
+
+    def _load_todos(self) -> list[TodoItem]:
+        if not DATA_FILE.exists():
+            return []
+
+        try:
+            data = json.loads(DATA_FILE.read_text(encoding="utf-8"))
+            return [TodoItem(**item) for item in data if "text" in item]
+        except (OSError, json.JSONDecodeError, TypeError):
+            return []
+
+    def _save_todos(self) -> None:
+        try:
+            payload = [asdict(item) for item in self.todos]
+            DATA_FILE.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        except OSError:
+            messagebox.showerror("저장 오류", "할 일 목록을 저장하지 못했습니다.")
+
+
+if __name__ == "__main__":
+    app = TodoApp()
+    app.mainloop()


### PR DESCRIPTION
### Motivation

- Provide a lightweight desktop Todo application with common usability features and local persistence for quick personal use and demos.

### Description

- Added `todo_desktop_app.py`, a Tkinter-based Todo app implementing add, toggle done, delete, clear completed, and list filtering (all/active/done).
- Implemented persistent storage using `todo_data.json` with JSON load/save in `_load_todos` and `_save_todos`.
- Added input conveniences such as Enter-to-add and double-click-to-toggle, and a status line showing totals.
- Updated `README.md` with run instructions (`python3 todo_desktop_app.py`) and a feature overview.

### Testing

- Verified syntax by running `python3 -m py_compile todo_desktop_app.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ea38c0b6883209a47bcc13a8ad117)